### PR TITLE
Remove deprecated SSLv3

### DIFF
--- a/scripts/lib/TrustAtHsH-Irondemo/lib/TrustAtHsH/Irondemo/AbstractIfmapPublishModule.pm
+++ b/scripts/lib/TrustAtHsH-Irondemo/lib/TrustAtHsH/Irondemo/AbstractIfmapPublishModule.pm
@@ -59,7 +59,6 @@ sub send_soap_publish_request {
 
 	# configure the user agent
 	my $ua = LWP::UserAgent->new;
-	$ua->ssl_opts( 'SSL_version' => 'SSLv3' );
 	$ua->ssl_opts( 'SSL_verify_mode' => 'SSL_VERIFY_NONE' ); # TODO enable server cert verification
 
 	my $result = 1;


### PR DESCRIPTION
SSLv3 is not only deprecated, but forcing it results in not being able to connect to an irond server. Removing the forced SSLv3 constraint allows for LWP to negotiate the used version and results in successful connection attempts.
